### PR TITLE
[27] feat: websockets server status push

### DIFF
--- a/.bruno/DivumDaemon/Minecraft/CreateMinecraftServer.yml
+++ b/.bruno/DivumDaemon/Minecraft/CreateMinecraftServer.yml
@@ -25,15 +25,6 @@ http:
       }
   auth: inherit
 
-scripts:
-  post-response: |-
-    let body = res.body;
-    if (body) {
-      let id = typeof body === 'string' ? body.replace(/^"|"$/g, '') : body;
-      bru.setEnvVar("server_id", id);
-      bru.setVar("server_id", id);
-    }
-
 settings:
   encodeUrl: true
   timeout: 0

--- a/.bruno/DivumDaemon/Minecraft/CreateMinecraftServer.yml
+++ b/.bruno/DivumDaemon/Minecraft/CreateMinecraftServer.yml
@@ -5,7 +5,7 @@ info:
 
 http:
   method: POST
-  url: "{{address}}/{{base_route}}/minecraft-servers/"
+  url: "{{address}}/{{base_route}}/minecraft-servers"
   body:
     type: json
     data: |-
@@ -18,12 +18,21 @@ http:
         "type": "VANILLA",
         "rcon_password": "parola",
         "server_name": "Divum's world",
-        "online_mode": false,
+        "online_mode": true,
         "mode": "survival",
         "enable_whitelist": true,
-        "whitelist": ["Dimpex0"]
+        "whitelist": ["Dimitar45"]
       }
   auth: inherit
+
+scripts:
+  post-response: |-
+    let body = res.body;
+    if (body) {
+      let id = typeof body === 'string' ? body.replace(/^"|"$/g, '') : body;
+      bru.setEnvVar("server_id", id);
+      bru.setVar("server_id", id);
+    }
 
 settings:
   encodeUrl: true

--- a/.bruno/DivumDaemon/Minecraft/DeleteMinecraftServer.yml
+++ b/.bruno/DivumDaemon/Minecraft/DeleteMinecraftServer.yml
@@ -1,11 +1,11 @@
 info:
-  name: StopMinecraftServer
+  name: DeleteMinecraftServer
   type: http
-  seq: 3
+  seq: 5
 
 http:
-  method: POST
-  url: "{{address}}/{{base_route}}/minecraft-servers/{{server_id}}/stop"
+  method: DELETE
+  url: "{{address}}/{{base_route}}/minecraft-servers/{{server_id}}"
   auth: inherit
 
 settings:

--- a/.bruno/DivumDaemon/Minecraft/GetMinecraftServerStatus.yml
+++ b/.bruno/DivumDaemon/Minecraft/GetMinecraftServerStatus.yml
@@ -1,0 +1,7 @@
+info:
+  name: GetMinecraftServerStatus
+  type: websocket
+  seq: 6
+
+websocket:
+  url: "{{ws_address}}/{{base_route}}/minecraft-servers/{{server_id}}/status/ws"

--- a/.bruno/DivumDaemon/Minecraft/StartMinecraftServer.yml
+++ b/.bruno/DivumDaemon/Minecraft/StartMinecraftServer.yml
@@ -5,7 +5,7 @@ info:
 
 http:
   method: POST
-  url: "{{address}}/{{base_route}}/minecraft-servers/11569021-9086-45ff-99fd-920c80e4af88/start"
+  url: "{{address}}/{{base_route}}/minecraft-servers/{{server_id}}/start"
   auth: inherit
 
 settings:

--- a/.bruno/DivumDaemon/Minecraft/UpdateMinecraftServer.yml
+++ b/.bruno/DivumDaemon/Minecraft/UpdateMinecraftServer.yml
@@ -4,8 +4,8 @@ info:
   seq: 4
 
 http:
-  method: POST
-  url: "{{address}}/{{base_route}}/minecraft-servers/df77235e-1c38-40df-be57-d95b866f0fdd/update"
+  method: PATCH
+  url: "{{address}}/{{base_route}}/minecraft-servers/{{server_id}}"
   body:
     type: json
     data: |-

--- a/.bruno/DivumDaemon/environments/dev.yml
+++ b/.bruno/DivumDaemon/environments/dev.yml
@@ -4,3 +4,7 @@ variables:
     value: http://localhost:8000
   - name: base_route
     value: api/v1
+  - name: ws_address
+    value: ws://localhost:8000
+  - name: server_id
+    value: 4c97a1d5-e38e-419c-bab4-84c15670935a

--- a/src/dependencies/services.py
+++ b/src/dependencies/services.py
@@ -2,15 +2,17 @@ from typing import Optional
 
 from fastapi import Depends
 
-from services.minecraft.docker_server_manager import DockerServerManager
+from services.minecraft.docker_minecraft_server_manager import (
+    DockerMinecraftServerManager,
+)
 from services.minecraft.mc_proxy_router_service import MCProxyRouterService
 from services.minecraft.proxy_router import ProxyRouter
-from services.minecraft.server_manager import ServerManager
-
+from services.minecraft.minecraft_server_manager import MinecraftServerManager
 
 # Global holders for the singleton instances
 _proxy_router_instance: Optional[ProxyRouter] = None
-_server_manager_instance: Optional[ServerManager] = None
+_server_manager_instance: Optional[MinecraftServerManager] = None
+
 
 def get_mc_proxy_router() -> ProxyRouter:
     """Provides a singleton instance of ProxyRouter."""
@@ -20,12 +22,13 @@ def get_mc_proxy_router() -> ProxyRouter:
         _proxy_router_instance = MCProxyRouterService()
     return _proxy_router_instance
 
+
 def get_docker_server_manager(
-    router: ProxyRouter = Depends(get_mc_proxy_router)
-) -> ServerManager:
+    router: ProxyRouter = Depends(get_mc_proxy_router),
+) -> MinecraftServerManager:
     """Provides a singleton instance of ServerManager, managed by DI."""
     global _server_manager_instance
     if _server_manager_instance is None:
         # We use the 'router' provided by the DI container
-        _server_manager_instance = DockerServerManager(router)
+        _server_manager_instance = DockerMinecraftServerManager(router)
     return _server_manager_instance

--- a/src/main.py
+++ b/src/main.py
@@ -7,25 +7,29 @@ from contextlib import asynccontextmanager
 
 
 from dependencies.services import get_docker_server_manager, get_mc_proxy_router
-from services.minecraft.docker_event_watcher import DockerEventWatcher
+from services.minecraft.docker_minecraft_event_watcher import (
+    DockerMinecraftEventWatcher,
+)
 
 from fastapi import APIRouter, FastAPI
 
 from routers.minecraft_server_router import minecraft_server_router
+
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     main_loop = asyncio.get_running_loop()
     router = get_mc_proxy_router()
     server_manager = get_docker_server_manager(router)
-    watcher = DockerEventWatcher(server_manager, main_loop)
+    watcher = DockerMinecraftEventWatcher(server_manager, main_loop)
     watcher.start()
     yield
+
 
 app = FastAPI(
     title="DivumDaemon",
     swagger_ui_parameters={"syntaxHighlight": {"theme": "dracula"}},
-    lifespan=lifespan
+    lifespan=lifespan,
 )
 
 main_router = APIRouter(prefix="/api")

--- a/src/routers/minecraft_server_router.py
+++ b/src/routers/minecraft_server_router.py
@@ -2,9 +2,10 @@
 The router containing Minecraft server-related endpoints.
 """
 
+import asyncio
 from typing import Annotated, Union
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, WebSocket, WebSocketDisconnect
 from pydantic import Field
 
 from dependencies.services import get_docker_server_manager
@@ -56,7 +57,9 @@ async def start_minecraft_server(
     server_started: bool = await server_manager.start(id)
 
     if not server_started:
-        raise HTTPException(404, "No Minecraft server instance exists with the given ID.")
+        raise HTTPException(
+            404, "No Minecraft server instance exists with the given ID."
+        )
     return
 
 
@@ -68,7 +71,9 @@ async def stop_minecraft_server(id: str, server_manager: DockerServerManagerDepe
     server_stopped: bool = await server_manager.stop(id)
 
     if not server_stopped:
-        raise HTTPException(404, "No Minecraft server instance exists with the given ID.")
+        raise HTTPException(
+            404, "No Minecraft server instance exists with the given ID."
+        )
 
 
 @minecraft_server_router.patch("/{id}", status_code=204)
@@ -99,3 +104,20 @@ async def delete_minecraft_server(
         raise HTTPException(
             404, "No Minecraft server instance exists with the given ID."
         )
+
+
+@minecraft_server_router.websocket("/{id}/status/ws")
+async def get_minecraft_server_status(
+    websocket: WebSocket, id: str, server_manager: DockerServerManagerDependency
+):
+    await websocket.accept()
+
+    try:
+        while True:
+            status = await server_manager.status(id)
+
+            await websocket.send_json(status)
+
+            await asyncio.sleep(3)
+    except WebSocketDisconnect:
+        pass

--- a/src/routers/minecraft_server_router.py
+++ b/src/routers/minecraft_server_router.py
@@ -110,13 +110,15 @@ async def delete_minecraft_server(
 async def get_minecraft_server_status(
     websocket: WebSocket, id: str, server_manager: DockerServerManagerDependency
 ):
+    """A websocket endpoint for sending server status every three seconds."""
+
     await websocket.accept()
 
     try:
         while True:
-            status = await server_manager.status(id)
+            status = await server_manager.get_status(id)
 
-            await websocket.send_json(status)
+            await websocket.send_json(status.model_dump())
 
             await asyncio.sleep(3)
     except WebSocketDisconnect:

--- a/src/routers/minecraft_server_router.py
+++ b/src/routers/minecraft_server_router.py
@@ -5,7 +5,14 @@ The router containing Minecraft server-related endpoints.
 import asyncio
 from typing import Annotated, Union
 
-from fastapi import APIRouter, Depends, HTTPException, WebSocket, WebSocketDisconnect
+from fastapi import (
+    APIRouter,
+    Depends,
+    HTTPException,
+    WebSocket,
+    WebSocketDisconnect,
+    status,
+)
 from pydantic import Field
 
 from dependencies.services import get_docker_server_manager
@@ -19,6 +26,7 @@ from schemas.minecraft_server_config.minecraft_fabric_server_config import (
 from schemas.minecraft_server_config.minecraft_vanilla_server_config import (
     MinecraftVanillaServerConfig,
 )
+from schemas.minecraft_server_status import MinecraftServerStatus
 from services.minecraft.minecraft_server_manager import MinecraftServerManager
 
 DockerServerManagerDependency = Annotated[
@@ -116,18 +124,16 @@ async def get_minecraft_server_status(
 ):
     """A websocket endpoint for sending server status every three seconds."""
 
-    await websocket.accept()
-
     try:
-        while True:
-            status = await server_manager.get_status(id)
+        await websocket.accept()
 
-            await websocket.send_json(status.model_dump())
+        while True:
+            server_status = await server_manager.get_status(id)
+
+            await websocket.send_json(server_status.model_dump())
 
             await asyncio.sleep(3)
-    except (DockerContainerNotFoundException, ClientAPIException) as ex:
-        await websocket.send_json({"error": str(ex)})
-
-        await websocket.close()
+    except (ClientAPIException, DockerContainerNotFoundException) as ex:
+        await websocket.close(code=status.WS_1008_POLICY_VIOLATION, reason=str(ex))
     except WebSocketDisconnect:
         pass

--- a/src/routers/minecraft_server_router.py
+++ b/src/routers/minecraft_server_router.py
@@ -9,16 +9,20 @@ from fastapi import APIRouter, Depends, HTTPException, WebSocket, WebSocketDisco
 from pydantic import Field
 
 from dependencies.services import get_docker_server_manager
+from exceptions.client_api_exception import ClientAPIException
+from exceptions.docker_container_not_found_exception import (
+    DockerContainerNotFoundException,
+)
 from schemas.minecraft_server_config.minecraft_fabric_server_config import (
     MinecraftFabricServerConfig,
 )
 from schemas.minecraft_server_config.minecraft_vanilla_server_config import (
     MinecraftVanillaServerConfig,
 )
-from services.minecraft.server_manager import ServerManager
+from services.minecraft.minecraft_server_manager import MinecraftServerManager
 
 DockerServerManagerDependency = Annotated[
-    ServerManager, Depends(get_docker_server_manager)
+    MinecraftServerManager, Depends(get_docker_server_manager)
 ]
 
 minecraft_server_router = APIRouter(
@@ -121,5 +125,9 @@ async def get_minecraft_server_status(
             await websocket.send_json(status.model_dump())
 
             await asyncio.sleep(3)
+    except (DockerContainerNotFoundException, ClientAPIException) as ex:
+        await websocket.send_json({"error": str(ex)})
+
+        await websocket.close()
     except WebSocketDisconnect:
         pass

--- a/src/schemas/minecraft_server_status.py
+++ b/src/schemas/minecraft_server_status.py
@@ -1,7 +1,11 @@
+"""DTOs for a Minecraft server instance's status"""
+
 from pydantic import BaseModel, Field
 from enum import Enum
 
+
 class Status(str, Enum):
+    """Values for the Minecraft server instance's state"""
     CREATED = "created"
     RESTARTING = "restarting"
     RUNNING = "running"
@@ -9,9 +13,11 @@ class Status(str, Enum):
     EXITED = "exited"
     DEAD = "dead"
 
-class MinecraftServerStatus(BaseModel):
-    # status of the minecraft instance according to the ServerManager's API
-    status: Status = Field(...)
 
-    # last lines of the log from the minecraft instance
-    log: str = Field(...)
+class MinecraftServerStatus(BaseModel):
+    """The Minecraft server instance's status"""
+
+    status: Status = Field(...)
+    player_count: int = Field(...)
+    ram_usage_mb: int = Field(...)
+    cpu_usage_percentage: float = Field(...)

--- a/src/schemas/minecraft_server_status.py
+++ b/src/schemas/minecraft_server_status.py
@@ -29,3 +29,5 @@ class MinecraftServerStatus(BaseModel):
     player_count: int = Field(...)
     ram_usage_mb: int = Field(...)
     cpu_usage_percentage: float = Field(...)
+    ram_usage_limit_mb: int = Field(...)
+    cpu_usage_limit_percentage: float = Field(...)

--- a/src/schemas/minecraft_server_status.py
+++ b/src/schemas/minecraft_server_status.py
@@ -4,8 +4,9 @@ from pydantic import BaseModel, Field
 from enum import Enum
 
 
-class Status(str, Enum):
-    """Values for the Minecraft server instance's state"""
+class MinecraftDockerContainerStatus(str, Enum):
+    """Values for the Minecraft server instance's docker container state."""
+
     CREATED = "created"
     RESTARTING = "restarting"
     RUNNING = "running"
@@ -13,11 +14,18 @@ class Status(str, Enum):
     EXITED = "exited"
     DEAD = "dead"
 
+class MinecraftServerInstanceStatus(str, Enum):
+    """Values for the Minecraft server instance's state."""
+
+    STARTING = "starting"
+    RESTARTING = "restarting"
+    RUNNING = "running"
+    STOPPED = "stopped"
 
 class MinecraftServerStatus(BaseModel):
     """The Minecraft server instance's status"""
 
-    status: Status = Field(...)
+    status: MinecraftServerInstanceStatus = Field(...)
     player_count: int = Field(...)
     ram_usage_mb: int = Field(...)
     cpu_usage_percentage: float = Field(...)

--- a/src/services/minecraft/docker_minecraft_event_watcher.py
+++ b/src/services/minecraft/docker_minecraft_event_watcher.py
@@ -7,13 +7,18 @@ import docker
 from pydantic import TypeAdapter
 
 from routers.minecraft_server_router import MinecraftServerConfig
-from services.minecraft.server_manager import ServerManager
+from services.minecraft.minecraft_server_manager import MinecraftServerManager
 
 WORLDS_DIR = os.getenv("WORLDS_DIR", "../..")
 
-class DockerEventWatcher:
-    def __init__(self, server_manager: ServerManager, main_loop: asyncio.AbstractEventLoop):
-        self._server_manager: ServerManager = server_manager
+
+class DockerMinecraftEventWatcher:
+    def __init__(
+        self,
+        server_manager: MinecraftServerManager,
+        main_loop: asyncio.AbstractEventLoop,
+    ):
+        self._server_manager: MinecraftServerManager = server_manager
         self._client = docker.from_env()
         self._main_loop: asyncio.AbstractEventLoop = main_loop
         self._thread = None
@@ -30,21 +35,24 @@ class DockerEventWatcher:
             if not container_name:
                 continue
 
-            pending_path = os.path.abspath(f"{WORLDS_DIR}/data/{container_name}/.pending_config.json")
+            pending_path = os.path.abspath(
+                f"{WORLDS_DIR}/data/{container_name}/.pending_config.json"
+            )
 
             if os.path.exists(pending_path):
                 try:
                     with open(pending_path, "r") as f:
                         config_data = f.read()
-                        pending_config = TypeAdapter(MinecraftServerConfig).validate_json(config_data)
+                        pending_config = TypeAdapter(
+                            MinecraftServerConfig
+                        ).validate_json(config_data)
 
                         os.remove(pending_path)
 
                         future = asyncio.run_coroutine_threadsafe(
                             self._server_manager.update(container_name, pending_config),
-                            self._main_loop
+                            self._main_loop,
                         )
                         future.result()
                 except Exception as e:
                     print(f"Failed to apply pending config for {container_name}: {e}")
-

--- a/src/services/minecraft/docker_minecraft_server_manager.py
+++ b/src/services/minecraft/docker_minecraft_server_manager.py
@@ -20,6 +20,9 @@ import hashlib
 
 import os
 
+import re
+from re import Match
+
 import uuid
 
 import docker
@@ -38,7 +41,7 @@ from exceptions.docker_container_not_found_exception import (
 )
 
 from services.minecraft.proxy_router import ProxyRouter
-from services.minecraft.server_manager import ServerManager
+from services.minecraft.minecraft_server_manager import MinecraftServerManager
 
 from schemas.minecraft_server_status import MinecraftServerStatus, Status
 from schemas.minecraft_server_config.minecraft_server_config import (
@@ -50,9 +53,9 @@ DOCKER_NETWORK_NAME = os.environ.get("DOCKER_NETWORK_NAME", "divum-net")
 
 
 # TODO: add logging
-class DockerServerManager(ServerManager):
+class DockerMinecraftServerManager(MinecraftServerManager):
     """
-    The service responsible for handling Minecraft server container instances.
+    The service responsible for handling Minecraft server Docker container instances.
     """
 
     MC_CONTAINER_PORT: int = 25565
@@ -325,10 +328,14 @@ class DockerServerManager(ServerManager):
             return False
 
         if "DIFFICULTY" in changed_keys:
-            await self._run_rcon_command(container, f"difficulty {new_config.difficulty}")
+            await self._run_rcon_command(
+                container, f"difficulty {new_config.difficulty}"
+            )
 
         if "MODE" in changed_keys:
-            await self._run_rcon_command(container, f"defaultgamemode {new_config.mode}")
+            await self._run_rcon_command(
+                container, f"defaultgamemode {new_config.mode}"
+            )
             await self._run_rcon_command(container, f"gamemode {new_config.mode} @a")
 
         if "WHITELIST" in changed_keys:

--- a/src/services/minecraft/docker_minecraft_server_manager.py
+++ b/src/services/minecraft/docker_minecraft_server_manager.py
@@ -184,6 +184,24 @@ class DockerMinecraftServerManager(MinecraftServerManager):
                 case _:
                     server_instance_status = MinecraftServerInstanceStatus.STOPPED
 
+            container_env_vars: list[Any] = container.attrs.get("Config", {}).get(
+                "Env", []
+            )
+
+            memory_env: str = next(
+                (env for env in container_env_vars if env.startswith("MEMORY=")),
+                "MEMORY=0M",
+            )
+
+            ram_limit_mb: int = int(memory_env.split("=")[1].replace("M", ""))
+
+            nano_cpus: int = container.attrs.get("HostConfig", {}).get("NanoCpus", 0)
+
+            cpu_limit_percentage: float = (
+                (nano_cpus / DOCKER_CONTAINER_CPU_MULTIPLIER) * 100.0
+                if nano_cpus > 0
+                else 0.0
+            )
 
             if server_instance_status is not MinecraftServerInstanceStatus.RUNNING:
                 return MinecraftServerStatus(
@@ -191,20 +209,9 @@ class DockerMinecraftServerManager(MinecraftServerManager):
                     player_count=0,
                     ram_usage_mb=0,
                     cpu_usage_percentage=0.0,
+                    ram_usage_limit_mb=ram_limit_mb,
+                    cpu_usage_limit_percentage=cpu_limit_percentage,
                 )
-
-            memory_stats: dict[str, Any] = container_stats.get("memory_stats") or {}
-
-            memory_stats_details: dict[str, Any] = memory_stats.get("stats") or {}
-
-            page_cache_memory: int = (
-                memory_stats_details.get("inactive_file")
-                or memory_stats_details.get("total_inactive_file")
-                or memory_stats_details.get("cache")
-                or 0
-            )
-
-            raw_ram_usage: int = memory_stats.get("usage") or 0
 
             effective_ram_usage: int = raw_ram_usage - page_cache_memory
 
@@ -220,7 +227,9 @@ class DockerMinecraftServerManager(MinecraftServerManager):
                 status=server_instance_status,
                 player_count=int(player_count_match[0]) if player_count_match else 0,
                 ram_usage_mb=int(effective_ram_usage / (1000 * 1000)),
-                cpu_usage_percentage=cpu_usage_percentage
+                cpu_usage_percentage=cpu_usage_percentage,
+                ram_usage_limit_mb=ram_limit_mb,
+                cpu_usage_limit_percentage=cpu_limit_percentage,
             )
 
         except NotFound as ex:

--- a/src/services/minecraft/docker_minecraft_server_manager.py
+++ b/src/services/minecraft/docker_minecraft_server_manager.py
@@ -43,7 +43,11 @@ from exceptions.docker_container_not_found_exception import (
 from services.minecraft.proxy_router import ProxyRouter
 from services.minecraft.minecraft_server_manager import MinecraftServerManager
 
-from schemas.minecraft_server_status import MinecraftServerStatus, Status
+from schemas.minecraft_server_status import (
+    MinecraftServerInstanceStatus,
+    MinecraftServerStatus,
+    MinecraftDockerContainerStatus,
+)
 from schemas.minecraft_server_config.minecraft_server_config import (
     MinecraftServerConfig,
 )
@@ -100,7 +104,7 @@ class DockerMinecraftServerManager(MinecraftServerManager):
             # TODO: log
             raise DockerContainerNotFoundException(server_id)
 
-        was_running: bool = container.status == Status.RUNNING
+        was_running: bool = container.status == MinecraftDockerContainerStatus.RUNNING
 
         # Extract all variables from the container
         current_env = {}
@@ -166,9 +170,24 @@ class DockerMinecraftServerManager(MinecraftServerManager):
                 await asyncio.to_thread(container.stats, stream=False),
             )
 
-            if container.status is not Status.RUNNING:
+            docker_container_status: MinecraftDockerContainerStatus = (
+                MinecraftDockerContainerStatus(value=container.status)
+            )
+
+            server_instance_status: MinecraftServerInstanceStatus
+
+            match docker_container_status:
+                case MinecraftDockerContainerStatus.RUNNING:
+                    server_instance_status = MinecraftServerInstanceStatus.RUNNING
+                case MinecraftDockerContainerStatus.RESTARTING:
+                    server_instance_status = MinecraftServerInstanceStatus.RESTARTING
+                case _:
+                    server_instance_status = MinecraftServerInstanceStatus.STOPPED
+
+
+            if server_instance_status is not MinecraftServerInstanceStatus.RUNNING:
                 return MinecraftServerStatus(
-                    status=Status(value=container.status),
+                    status=server_instance_status,
                     player_count=0,
                     ram_usage_mb=0,
                     cpu_usage_percentage=0.0,

--- a/src/services/minecraft/docker_minecraft_server_manager.py
+++ b/src/services/minecraft/docker_minecraft_server_manager.py
@@ -554,16 +554,20 @@ class DockerMinecraftServerManager(MinecraftServerManager):
             return None
 
     @staticmethod
-    def _calculate_cpu_percentage(stats: dict[str, Any]) -> float:
-        cpu_stats = stats.get("cpu_stats", {})
-        precpu_stats = stats.get("precpu_stats", {})
+    def _calculate_cpu_usage_percentage(stats: dict[str, Any]) -> float:
+        cpu_stats: dict[str, Any] = stats.get("cpu_stats") or {}
+        precpu_stats: dict[str, Any] = stats.get("precpu_stats") or {}
 
-        cpu_count = cpu_stats.get("online_cpus", 1)
-        cpu_delta = cpu_stats.get("cpu_usage", {}).get(
-            "total_usage", 0
-        ) - precpu_stats.get("cpu_usage", {}).get("total_usage", 0)
-        system_delta = cpu_stats.get("system_cpu_usage", 0) - precpu_stats.get(
-            "system_cpu_usage", 0
+        cpu_count: int = cpu_stats.get("online_cpus") or 1
+
+        cpu_usage: dict[str, Any] = cpu_stats.get("cpu_usage") or {}
+        precpu_usage: dict[str, Any] = precpu_stats.get("cpu_usage") or {}
+
+        cpu_delta: int = (cpu_usage.get("total_usage") or 0) - (
+            precpu_usage.get("total_usage") or 0
+        )
+        system_delta: int = (cpu_stats.get("system_cpu_usage") or 0) - (
+            precpu_stats.get("system_cpu_usage") or 0
         )
 
         if system_delta > 0 and cpu_delta > 0:

--- a/src/services/minecraft/docker_minecraft_server_manager.py
+++ b/src/services/minecraft/docker_minecraft_server_manager.py
@@ -213,11 +213,15 @@ class DockerMinecraftServerManager(MinecraftServerManager):
                     cpu_usage_limit_percentage=cpu_limit_percentage,
                 )
 
-            effective_ram_usage: int = raw_ram_usage - page_cache_memory
+            effective_ram_usage: int = self._calculate_memory_usage(container_stats)
 
-            cpu_usage_percentage: float = self._calculate_cpu_usage_percentage(container_stats)
+            cpu_usage_percentage: float = self._calculate_cpu_usage_percentage(
+                container_stats
+            )
 
-            player_count_output: str | None = await self._execute_rcon_command(container, "list")
+            player_count_output: str | None = await self._execute_rcon_command(
+                container, "list"
+            )
 
             player_count_match: Match[str] | None = re.search(
                 r"\d+", player_count_output or ""
@@ -452,7 +456,10 @@ class DockerMinecraftServerManager(MinecraftServerManager):
 
     @staticmethod
     async def _run_rcon_command(container: Container, command: str) -> bool:
-        return await DockerMinecraftServerManager._execute_rcon_command(container, command) is not None
+        return (
+            await DockerMinecraftServerManager._execute_rcon_command(container, command)
+            is not None
+        )
 
     async def _migrate_all_players(self, server_id: str, changing_to_online_mode: bool):
         """Finds all known players and bulk-migrates their data"""
@@ -568,6 +575,22 @@ class DockerMinecraftServerManager(MinecraftServerManager):
         except ClientConnectionError:
             # TODO: log mojang api call failed
             return None
+
+    @staticmethod
+    def _calculate_memory_usage(stats: dict[str, Any]) -> int:
+        memory_stats: dict[str, Any] = stats.get("memory_stats") or {}
+        memory_stats_details: dict[str, Any] = memory_stats.get("stats") or {}
+
+        page_cache_memory: int = (
+            memory_stats_details.get("inactive_file")
+            or memory_stats_details.get("total_inactive_file")
+            or memory_stats_details.get("cache")
+            or 0
+        )
+
+        raw_ram_usage: int = memory_stats.get("usage") or 0
+
+        return raw_ram_usage - page_cache_memory
 
     @staticmethod
     def _calculate_cpu_usage_percentage(stats: dict[str, Any]) -> float:

--- a/src/services/minecraft/docker_minecraft_server_manager.py
+++ b/src/services/minecraft/docker_minecraft_server_manager.py
@@ -163,13 +163,36 @@ class DockerMinecraftServerManager(MinecraftServerManager):
 
             container_stats: dict[str, Any] = cast(
                 dict[str, Any],
-                await asyncio.to_thread(
-                    container.stats, stream=False, decode=True
-            ))
+                await asyncio.to_thread(container.stats, stream=False),
+            )
 
-            player_count: int = await self._run_rcon_command(container, "list")
+            if container.status is not Status.RUNNING:
+                return MinecraftServerStatus(
+                    status=Status(value=container.status),
+                    player_count=0,
+                    ram_usage_mb=0,
+                    cpu_usage_percentage=0.0,
+                )
 
-            return MinecraftServerStatus(Status(container.status), container_stats)           
+            player_count_output = await self._execute_rcon_command(container, "list")
+
+            player_count_match: Match[str] | None = re.search(
+                r"\d+", player_count_output or ""
+            )
+
+            if not player_count_match:
+                raise APIError(
+                    "An error occurred while trying to retrieve the player count."
+                )
+
+            return MinecraftServerStatus(
+                status=Status(value=container.status),
+                player_count=int(player_count_match[0]) if player_count_match else 0,
+                ram_usage_mb=int(
+                    container_stats["memory_stats"]["usage"] / (1024 * 1024)
+                ),
+                cpu_usage_percentage=self._calculate_cpu_percentage(container_stats),
+            )
 
         except NotFound as ex:
             raise DockerContainerNotFoundException(server_id) from ex
@@ -375,15 +398,26 @@ class DockerMinecraftServerManager(MinecraftServerManager):
         return True
 
     @staticmethod
-    async def _run_rcon_command(container: Container, command: str) -> bool:
+    async def _execute_rcon_command(container: Container, command: str) -> str | None:
         if container is None:
-            return False
+            return None
 
         try:
-            await asyncio.to_thread(container.exec_run, f"rcon-cli {command}")
-            return True
+            exit_code, output = await asyncio.to_thread(
+                container.exec_run, f"rcon-cli {command}"
+            )
+            if exit_code == 0:
+                return output.decode("utf-8").strip() if output else ""
+            return None
         except APIError:
-            return False
+            return None
+
+    @staticmethod
+    async def _run_rcon_command(container: Container, command: str) -> bool:
+        return (
+            await self._execute_rcon_command(container, command)
+            is not None
+        )
 
     async def _migrate_all_players(self, server_id: str, changing_to_online_mode: bool):
         """Finds all known players and bulk-migrates their data"""
@@ -499,3 +533,20 @@ class DockerMinecraftServerManager(MinecraftServerManager):
         except ClientConnectionError:
             # TODO: log mojang api call failed
             return None
+
+    @staticmethod
+    def _calculate_cpu_percentage(stats: dict[str, Any]) -> float:
+        cpu_stats = stats.get("cpu_stats", {})
+        precpu_stats = stats.get("precpu_stats", {})
+
+        cpu_count = cpu_stats.get("online_cpus", 1)
+        cpu_delta = cpu_stats.get("cpu_usage", {}).get(
+            "total_usage", 0
+        ) - precpu_stats.get("cpu_usage", {}).get("total_usage", 0)
+        system_delta = cpu_stats.get("system_cpu_usage", 0) - precpu_stats.get(
+            "system_cpu_usage", 0
+        )
+
+        if system_delta > 0 and cpu_delta > 0:
+            return round((cpu_delta / system_delta) * cpu_count * 100.0, 2)
+        return 0.0

--- a/src/services/minecraft/docker_minecraft_server_manager.py
+++ b/src/services/minecraft/docker_minecraft_server_manager.py
@@ -193,24 +193,34 @@ class DockerMinecraftServerManager(MinecraftServerManager):
                     cpu_usage_percentage=0.0,
                 )
 
-            player_count_output = await self._execute_rcon_command(container, "list")
+            memory_stats: dict[str, Any] = container_stats.get("memory_stats") or {}
+
+            memory_stats_details: dict[str, Any] = memory_stats.get("stats") or {}
+
+            page_cache_memory: int = (
+                memory_stats_details.get("inactive_file")
+                or memory_stats_details.get("total_inactive_file")
+                or memory_stats_details.get("cache")
+                or 0
+            )
+
+            raw_ram_usage: int = memory_stats.get("usage") or 0
+
+            effective_ram_usage: int = raw_ram_usage - page_cache_memory
+
+            cpu_usage_percentage: float = self._calculate_cpu_usage_percentage(container_stats)
+
+            player_count_output: str | None = await self._execute_rcon_command(container, "list")
 
             player_count_match: Match[str] | None = re.search(
                 r"\d+", player_count_output or ""
             )
 
-            if not player_count_match:
-                raise APIError(
-                    "An error occurred while trying to retrieve the player count."
-                )
-
             return MinecraftServerStatus(
-                status=Status(value=container.status),
+                status=server_instance_status,
                 player_count=int(player_count_match[0]) if player_count_match else 0,
-                ram_usage_mb=int(
-                    container_stats["memory_stats"]["usage"] / (1024 * 1024)
-                ),
-                cpu_usage_percentage=self._calculate_cpu_percentage(container_stats),
+                ram_usage_mb=int(effective_ram_usage / (1000 * 1000)),
+                cpu_usage_percentage=cpu_usage_percentage
             )
 
         except NotFound as ex:
@@ -433,10 +443,7 @@ class DockerMinecraftServerManager(MinecraftServerManager):
 
     @staticmethod
     async def _run_rcon_command(container: Container, command: str) -> bool:
-        return (
-            await self._execute_rcon_command(container, command)
-            is not None
-        )
+        return await DockerMinecraftServerManager._execute_rcon_command(container, command) is not None
 
     async def _migrate_all_players(self, server_id: str, changing_to_online_mode: bool):
         """Finds all known players and bulk-migrates their data"""

--- a/src/services/minecraft/docker_server_manager.py
+++ b/src/services/minecraft/docker_server_manager.py
@@ -1,9 +1,10 @@
 """
 Contains the main service responsible for handling Minecraft server container instances.
 """
+
 import json
 import shutil
-from typing import AnyStr
+from typing import Any, AnyStr, cast
 
 import aiofiles
 import aiofiles.os
@@ -25,18 +26,24 @@ import docker
 from docker.models.containers import Container
 from docker.errors import APIError, ImageNotFound, NotFound
 
-from constants.constants import MINECRAFT_SERVER_DOCKER_IMAGE, DOCKER_CONTAINER_CPU_MULTIPLIER, \
-    MC_ROUTER_CONTAINER_LABEL
+from constants.constants import (
+    MINECRAFT_SERVER_DOCKER_IMAGE,
+    DOCKER_CONTAINER_CPU_MULTIPLIER,
+    MC_ROUTER_CONTAINER_LABEL,
+)
 
 from exceptions.client_api_exception import ClientAPIException
-from exceptions.docker_container_not_found_exception import DockerContainerNotFoundException
+from exceptions.docker_container_not_found_exception import (
+    DockerContainerNotFoundException,
+)
 
 from services.minecraft.proxy_router import ProxyRouter
 from services.minecraft.server_manager import ServerManager
 
 from schemas.minecraft_server_status import MinecraftServerStatus, Status
-from schemas.minecraft_server_config.minecraft_server_config import MinecraftServerConfig
-
+from schemas.minecraft_server_config.minecraft_server_config import (
+    MinecraftServerConfig,
+)
 
 WORLDS_DIR = os.environ.get("WORLDS_DIR", "../..")
 DOCKER_NETWORK_NAME = os.environ.get("DOCKER_NETWORK_NAME", "divum-net")
@@ -57,7 +64,6 @@ class DockerServerManager(ServerManager):
         except Exception as err:
             raise ClientAPIException("Couldn't start the Docker client.") from err
 
-
     async def create(self, config: MinecraftServerConfig) -> str | None:
         """Creates an itzg/minecraft-server container with the given configuration"""
 
@@ -67,7 +73,9 @@ class DockerServerManager(ServerManager):
         host_path = os.path.abspath(f"{WORLDS_DIR}/data/{container_name}")
         await aiofiles.os.makedirs(host_path)
 
-        container: Container | None = await self._create_container(container_name, config, host_path)
+        container: Container | None = await self._create_container(
+            container_name, config, host_path
+        )
 
         # remove the created the folder if creation failed
         if not container:
@@ -82,7 +90,6 @@ class DockerServerManager(ServerManager):
             return None
 
         return container.name
-
 
     async def update(self, server_id: str, new_config: MinecraftServerConfig) -> bool:
         container: Container | None = await self._get_container(server_id)
@@ -109,23 +116,33 @@ class DockerServerManager(ServerManager):
         server_address_changed: bool = current_address != new_address
 
         # Checks if the cpu limit has been changed
-        cpu_limit_changed: bool = (
-                int(new_config.cpu_cores_limit * DOCKER_CONTAINER_CPU_MULTIPLIER) != container.attrs["HostConfig"].get("NanoCpus")
+        cpu_limit_changed: bool = int(
+            new_config.cpu_cores_limit * DOCKER_CONTAINER_CPU_MULTIPLIER
+        ) != container.attrs["HostConfig"].get("NanoCpus")
+
+        requires_restart: bool = (
+            any(key not in self.HOT_UPDATE_KEYS for key in changed_keys)
+            or cpu_limit_changed
+            or server_address_changed
         )
 
-        requires_restart: bool = (any(key not in self.HOT_UPDATE_KEYS for key in changed_keys)
-                            or cpu_limit_changed
-                            or server_address_changed)
-
-        pending_path = os.path.abspath(f"{WORLDS_DIR}/data/{server_id}/.pending_config.json")
+        pending_path = os.path.abspath(
+            f"{WORLDS_DIR}/data/{server_id}/.pending_config.json"
+        )
         if requires_restart or not was_running:
-            pending_path = os.path.abspath(f"{WORLDS_DIR}/data/{server_id}/.pending_config.json")
+            pending_path = os.path.abspath(
+                f"{WORLDS_DIR}/data/{server_id}/.pending_config.json"
+            )
             if os.path.exists(pending_path):
                 await aiofiles.os.remove(pending_path)
 
             # current_env["ONLINE_MODE"] returns a string "TRUE" or "FALSE"
-            online_mode_changed: bool = current_env["ONLINE_MODE"] != new_env["ONLINE_MODE"]
-            return await self._recreate_container(server_id, new_config, online_mode_changed, was_running)
+            online_mode_changed: bool = (
+                current_env["ONLINE_MODE"] != new_env["ONLINE_MODE"]
+            )
+            return await self._recreate_container(
+                server_id, new_config, online_mode_changed, was_running
+            )
 
         # Generate a .pending_config.json file to be applied on server stop
         await self._apply_live_patches(server_id, new_config, changed_keys)
@@ -134,33 +151,29 @@ class DockerServerManager(ServerManager):
 
         return True
 
-    # TODO: remove-ni go toq bokluk che samo me drazni
-    async def status(self, server_id: str) -> MinecraftServerStatus:
+    async def get_status(self, server_id: str) -> MinecraftServerStatus:
+        """Returns a snapshot of the Minecraft server instance status (i.e. active players, ram and cpu usage, etc.)"""
         try:
             container: Container = await asyncio.to_thread(
                 self._client.containers.get, server_id
             )
 
-            status = container.status
-            log = "No logs"
+            container_stats: dict[str, Any] = cast(
+                dict[str, Any],
+                await asyncio.to_thread(
+                    container.stats, stream=False, decode=True
+            ))
 
-            # If the minecraft instance was very recently created, log files are not yet generated
-            host_path = os.path.abspath(
-                f"{WORLDS_DIR}/data/{container.name}/logs/latest.log"
-            )
-            if os.path.exists(host_path):
-                async with aiofiles.open(host_path, "r") as f:
-                    log = await f.read()
+            player_count: int = await self._run_rcon_command(container, "list")
 
-            return MinecraftServerStatus(status=Status(value=status), log=log)
+            return MinecraftServerStatus(Status(container.status), container_stats)           
 
         except NotFound as ex:
             raise DockerContainerNotFoundException(server_id) from ex
         except APIError as err:
             raise ClientAPIException(
-                f"An error occurred while trying to get the status of container '{server_id}'."
+                f"An error occurred while trying to get the status of server '{server_id}'."
             ) from err
-
 
     async def start(self, server_id: str) -> bool:
         try:
@@ -171,11 +184,10 @@ class DockerServerManager(ServerManager):
 
             await asyncio.to_thread(container.start)
 
-        except (NotFound, APIError):
+        except NotFound, APIError:
             return False
 
         return True
-
 
     async def stop(self, server_id: str) -> bool:
         try:
@@ -186,15 +198,13 @@ class DockerServerManager(ServerManager):
 
             await asyncio.to_thread(container.stop)
 
-        except (NotFound, APIError):
+        except NotFound, APIError:
             return False
 
         return True
 
-
     async def delete(self, server_id: str) -> bool:
         return await self._remove(server_id, permanently=True, force=True)
-
 
     async def _remove(self, server_id: str, permanently: bool, force: bool) -> bool:
         try:
@@ -209,11 +219,10 @@ class DockerServerManager(ServerManager):
                 if os.path.exists(host_path):
                     await asyncio.to_thread(shutil.rmtree, host_path)
 
-        except (NotFound, APIError):
+        except NotFound, APIError:
             return False
 
         return True
-
 
     async def _get_container(self, server_id: str) -> Container | None:
         try:
@@ -221,17 +230,28 @@ class DockerServerManager(ServerManager):
                 self._client.containers.get, server_id
             )
             return container
-        except (NotFound, APIError):
+        except NotFound, APIError:
             return None
 
-    async def _recreate_container(self, server_id: str, new_config: MinecraftServerConfig, online_mode_changed: bool, was_running: bool) -> bool:
+    async def _recreate_container(
+        self,
+        server_id: str,
+        new_config: MinecraftServerConfig,
+        online_mode_changed: bool,
+        was_running: bool,
+    ) -> bool:
         await self.stop(server_id)
         await self._remove(server_id, permanently=False, force=True)
 
         if online_mode_changed:
             await self._migrate_all_players(server_id, new_config.online_mode)
 
-            poisoned_files = ["usercache.json", "whitelist.json", "ops.json", "banned-players.json"]
+            poisoned_files = [
+                "usercache.json",
+                "whitelist.json",
+                "ops.json",
+                "banned-players.json",
+            ]
             for file_name in poisoned_files:
                 file_path = os.path.join(f"{WORLDS_DIR}/data/{server_id}", file_name)
                 if os.path.exists(file_path):
@@ -239,7 +259,9 @@ class DockerServerManager(ServerManager):
 
         host_path = os.path.abspath(f"{WORLDS_DIR}/data/{server_id}")
 
-        new_container: Container | None = await self._create_container(server_id, new_config, host_path)
+        new_container: Container | None = await self._create_container(
+            server_id, new_config, host_path
+        )
         if not new_container:
             raise CreateContainerException
 
@@ -248,10 +270,15 @@ class DockerServerManager(ServerManager):
 
         return True
 
-    async def _create_container(self, server_id: str, config: MinecraftServerConfig, host_path: AnyStr) -> Container | None:
+    async def _create_container(
+        self, server_id: str, config: MinecraftServerConfig, host_path: AnyStr
+    ) -> Container | None:
         try:
             if not config.online_mode and config.whitelist and config.enable_whitelist:
-                config.whitelist = [self._generate_offline_uuid(username) for username in config.whitelist]
+                config.whitelist = [
+                    self._generate_offline_uuid(username)
+                    for username in config.whitelist
+                ]
 
             new_container: Container = await asyncio.to_thread(
                 self._client.containers.create,
@@ -282,39 +309,40 @@ class DockerServerManager(ServerManager):
 
     async def _pull_image(self, image: str) -> bool:
         try:
-            await asyncio.to_thread(self._client.images.pull,
-                                repository=image,
-                                tag="latest"
-                                )
+            await asyncio.to_thread(
+                self._client.images.pull, repository=image, tag="latest"
+            )
         except APIError:
             return False
 
         return True
 
-
-    async def _apply_live_patches(self, server_id: str, new_config: MinecraftServerConfig, changed_keys: list[str]) -> bool:
+    async def _apply_live_patches(
+        self, server_id: str, new_config: MinecraftServerConfig, changed_keys: list[str]
+    ) -> bool:
         container: Container | None = await self._get_container(server_id)
         if not container:
             return False
 
         if "DIFFICULTY" in changed_keys:
-            await self._run_rcon(container, f"difficulty {new_config.difficulty}")
+            await self._run_rcon_command(container, f"difficulty {new_config.difficulty}")
 
         if "MODE" in changed_keys:
-            await self._run_rcon(container, f"defaultgamemode {new_config.mode}")
-            await self._run_rcon(container, f"gamemode {new_config.mode} @a")
+            await self._run_rcon_command(container, f"defaultgamemode {new_config.mode}")
+            await self._run_rcon_command(container, f"gamemode {new_config.mode} @a")
 
         if "WHITELIST" in changed_keys:
             # Enforce the whitelist
             if new_config.enable_whitelist:
-                await self._run_rcon(container, "whitelist on")
+                await self._run_rcon_command(container, "whitelist on")
             else:
-                await self._run_rcon(container, "whitelist off")
+                await self._run_rcon_command(container, "whitelist off")
 
             # Set the uuid generation strategy
             if new_config.online_mode:
                 get_uuid_strategy = self._get_premium_uuid
             else:
+
                 async def get_uuid_strategy(username: str):
                     return self._generate_offline_uuid(username)
 
@@ -328,17 +356,19 @@ class DockerServerManager(ServerManager):
                         whitelist_data.append({"uuid": player_uuid, "name": name})
 
             # Completely overwrite the whitelist.json file
-            whitelist_path = os.path.abspath(f"{WORLDS_DIR}/data/{server_id}/whitelist.json")
+            whitelist_path = os.path.abspath(
+                f"{WORLDS_DIR}/data/{server_id}/whitelist.json"
+            )
             async with aiofiles.open(whitelist_path, "w") as f:
                 await f.write(json.dumps(whitelist_data, indent=2))
 
             # Force the server to read the newly created file
-            await self._run_rcon(container, "whitelist reload")
+            await self._run_rcon_command(container, "whitelist reload")
 
         return True
 
     @staticmethod
-    async def _run_rcon(container: Container, command: str) -> bool:
+    async def _run_rcon_command(container: Container, command: str) -> bool:
         if container is None:
             return False
 
@@ -357,10 +387,13 @@ class DockerServerManager(ServerManager):
             return
 
         for username in usernames:
-            await self._migrate_player_data(server_id, username, changing_to_online_mode)
+            await self._migrate_player_data(
+                server_id, username, changing_to_online_mode
+            )
 
-
-    async def _migrate_player_data(self, server_id: str, username: str, changing_to_online_mode: bool) -> bool:
+    async def _migrate_player_data(
+        self, server_id: str, username: str, changing_to_online_mode: bool
+    ) -> bool:
         """Migrate a player's save files between offline and online UUIDs"""
 
         offline_uuid = self._generate_offline_uuid(username)
@@ -395,7 +428,6 @@ class DockerServerManager(ServerManager):
 
         return True
 
-
     @staticmethod
     async def _get_all_known_usernames(server_id: str) -> list[str]:
         """Reads the server's usercache.json to find every unique username"""
@@ -411,19 +443,20 @@ class DockerServerManager(ServerManager):
 
             json_data = json.loads(data)
 
-            unique_usernames: set[str] = {entry["name"] for entry in json_data if "name" in entry}
+            unique_usernames: set[str] = {
+                entry["name"] for entry in json_data if "name" in entry
+            }
 
             return list(unique_usernames)
 
-        except Exception as e:
+        except Exception:
             print(f"Failed to read usercache.json for {server_id}")
             raise
-
 
     @staticmethod
     def _generate_offline_uuid(username: str) -> str:
         # 1. Create the string
-        data = f"OfflinePlayer:{username}".encode('utf-8')
+        data = f"OfflinePlayer:{username}".encode("utf-8")
 
         # 2. Get the MD5 hash
         md5_hash = hashlib.md5(data).digest()
@@ -431,12 +464,15 @@ class DockerServerManager(ServerManager):
         # 3. Apply the UUID version 3 and variant bits
         # (Setting the 7th byte for version 3, and 9th byte for variant 2)
         uuid_bytes = bytearray(md5_hash)
-        uuid_bytes[6] = (uuid_bytes[6] & 0x0f) | 0x30  # remove first 4 bits and replace with the number 3 (0x30)
-        uuid_bytes[8] = (uuid_bytes[8] & 0x3f) | 0x80  # remove first 2 bits and replace with the number 8 (0x80)
+        uuid_bytes[6] = (
+            uuid_bytes[6] & 0x0F
+        ) | 0x30  # remove first 4 bits and replace with the number 3 (0x30)
+        uuid_bytes[8] = (
+            uuid_bytes[8] & 0x3F
+        ) | 0x80  # remove first 2 bits and replace with the number 8 (0x80)
 
         # 4. Return as a formatted UUID object/string
         return str(uuid.UUID(bytes=bytes(uuid_bytes)))
-
 
     @staticmethod
     async def _get_premium_uuid(username: str) -> str | None:

--- a/src/services/minecraft/mc_proxy_router_service.py
+++ b/src/services/minecraft/mc_proxy_router_service.py
@@ -10,7 +10,6 @@ ROUTER_API_ADDRESS = os.getenv("MC_ROUTER_API_ADDRESS", "")
 
 
 class MCProxyRouterService(ProxyRouter):
-
     async def add(self, server_address: str, server_host: str) -> bool:
         """Add an entry to the itzg/mc-router hosts"""
 

--- a/src/services/minecraft/minecraft_server_manager.py
+++ b/src/services/minecraft/minecraft_server_manager.py
@@ -6,7 +6,8 @@ from schemas.minecraft_server_config.minecraft_server_config import (
 )
 
 
-class ServerManager(ABC):
+class MinecraftServerManager(ABC):
+    """The abstract class for Minecraft server instance managers"""
     @abstractmethod
     async def create(self, config: MinecraftServerConfig) -> str | None:
         """Creates a server and return the unique identifier for it"""

--- a/src/services/minecraft/server_manager.py
+++ b/src/services/minecraft/server_manager.py
@@ -1,18 +1,18 @@
 from abc import ABC, abstractmethod
 
 from schemas.minecraft_server_status import MinecraftServerStatus
-from schemas.minecraft_server_config.minecraft_server_config import MinecraftServerConfig
+from schemas.minecraft_server_config.minecraft_server_config import (
+    MinecraftServerConfig,
+)
 
 
 class ServerManager(ABC):
     @abstractmethod
-    async def create(
-        self, config: MinecraftServerConfig
-    ) -> str | None:
+    async def create(self, config: MinecraftServerConfig) -> str | None:
         """Creates a server and return the unique identifier for it"""
 
     @abstractmethod
-    async def status(self, server_id: str) -> MinecraftServerStatus:
+    async def get_status(self, server_id: str) -> MinecraftServerStatus:
         """Returns the status of an existing instance and its logs"""
 
     @abstractmethod
@@ -25,6 +25,7 @@ class ServerManager(ABC):
 
     @abstractmethod
     async def update(self, server_id: str, new_config: MinecraftServerConfig) -> bool:
+        """Updates the minecraft server instance configuration"""
 
     @abstractmethod
     async def delete(self, server_id: str) -> bool:

--- a/src/services/minecraft/server_manager.py
+++ b/src/services/minecraft/server_manager.py
@@ -3,34 +3,29 @@ from abc import ABC, abstractmethod
 from schemas.minecraft_server_status import MinecraftServerStatus
 from schemas.minecraft_server_config.minecraft_server_config import MinecraftServerConfig
 
+
 class ServerManager(ABC):
     @abstractmethod
     async def create(
         self, config: MinecraftServerConfig
     ) -> str | None:
         """Creates a server and return the unique identifier for it"""
-        pass
 
     @abstractmethod
     async def status(self, server_id: str) -> MinecraftServerStatus:
         """Returns the status of an existing instance and its logs"""
-        pass
 
     @abstractmethod
     async def start(self, server_id: str) -> bool:
         """Starts an existing server"""
-        pass
 
     @abstractmethod
     async def stop(self, server_id: str) -> bool:
         """Stops an existing server"""
-        pass
 
     @abstractmethod
     async def update(self, server_id: str, new_config: MinecraftServerConfig) -> bool:
-        pass
 
     @abstractmethod
     async def delete(self, server_id: str) -> bool:
         """Deletes an existing server"""
-        pass


### PR DESCRIPTION
This PR adds a websocket endpoint that polls the docker API and sends an rcon command to retrieve player count, RAM and CPU usage and sends the dto it as a serialized json response.  Some refactoring of other functions/classes was done as well (mostly renaming). The endpoint closes the websocket with a POLICY VIOLATION code if any exception occurs (if the docker API throws or more often if the container is not found).